### PR TITLE
Add project urls to the setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,5 +47,10 @@ setup(
         'Topic :: Software Development',
         'Topic :: Utilities',
     ],
+    package_urls={
+        'Funding': 'https://pybee.org/contributing/membership/',
+        'Tracker': 'https://github.com/pybee/beeware/issues',
+        'Source': 'https://github.com/pybee/beeware',
+    },
     # test_suite='tests'
 )


### PR DESCRIPTION
setup.py now defines a spec for project urls, which results in a more
informative pypi page and helps downstream consumers of project information.